### PR TITLE
invert sequence when `getActiveConnector` is null

### DIFF
--- a/src/internal/connectivityhelper.ts
+++ b/src/internal/connectivityhelper.ts
@@ -15,8 +15,8 @@ export class ConnectivityHelper {
         else {
             // If no active connector but only one connector available, we auto-activate it.
             if (connectivity.getAvailableConnectors().length == 1) {
+                await connectivity.setActiveConnector(connectivity.getAvailableConnectors()[0].name);
                 this.sendContextToActiveConnector();
-                connectivity.setActiveConnector(connectivity.getAvailableConnectors()[0].name);
                 onActiveConnector();
             }
             else {


### PR DESCRIPTION
On null case, executing `this.sendContextToActiveConnector()` throw an error like `Uncaught (in promise) TypeError: Cannot use 'in' operator to search for 'setModuleContext' in null`
This PR just inverts the sequence of execution of the needed statements