### PR TITLE
fix lazy import of did-sdk

### DIFF
--- a/src/internal/connectivityhelper.ts
+++ b/src/internal/connectivityhelper.ts
@@ -40,7 +40,7 @@ export class ConnectivityHelper {
      */
     private static async sendContextToActiveConnector() {
         // Lazy import to reduce bundle sizes
-        const didSdk = (await import("@elastosfoundation/did-js-sdk")).default;
+        const didSdk = (await import("@elastosfoundation/did-js-sdk"));
         if ("setModuleContext" in connectivity.getActiveConnector())
             connectivity.getActiveConnector().setModuleContext(didSdk, connectivity);
     }


### PR DESCRIPTION
I recently continuing getting error like `This dApp uses a old version of the elastos connectivity SDK and must be upgraded to be able to run inside Elastos Essentials`

here were dependencies
```
    "@elastosfoundation/did-js-sdk": "^2.2.12",
    "@elastosfoundation/elastos-connectivity-sdk-js": "^1.1.9",
    "@elastosfoundation/essentials-connector-client-browser": "^1.0.41",
```

I noticed there is no default export in `did-sdk-js`, so hopefully fixing what we import get rid of this error